### PR TITLE
fix: use the getButtons with param in all cases

### DIFF
--- a/src/components/buttonView/buttonView.tsx
+++ b/src/components/buttonView/buttonView.tsx
@@ -5,19 +5,16 @@ import MiniCopyComponent from "../miniCopyComponent/miniCopyComponent";
 import useButtonsStore from "@/stores/buttonsStore";
 
 interface content {
-  idBtn: number;
   darkMode: boolean;
   setDarkMode: (darkMode: boolean) => void;
 }
 
-const ButtonView: React.FC<content> = ({ idBtn, darkMode, setDarkMode }) => {
-  const buttons = useButtonsStore((state) => state.buttons);
-
-  const button = buttons.filter((btn) => btn.id === idBtn);
+const ButtonView: React.FC<content> = ({ darkMode, setDarkMode }) => {
+  const button = useButtonsStore((state) => state.button);
 
   return (
     <div>
-      <Button codeString={button[0].tailwindCode} />
+      <Button codeString={button?.tailwindCode || ""} />
       <ul className="absolute bottom-0 right-0 m-4 flex gap-4">
         <li
           onClick={() => {
@@ -28,7 +25,7 @@ const ButtonView: React.FC<content> = ({ idBtn, darkMode, setDarkMode }) => {
           {darkMode ? <FaRegMoon /> : <IoSunnyOutline />}
         </li>
         <li>
-          <MiniCopyComponent text={button[0].cssCode} />
+          <MiniCopyComponent text={button?.cssCode || ""} />
         </li>
       </ul>
     </div>

--- a/src/components/codeComponent/codeComponent.tsx
+++ b/src/components/codeComponent/codeComponent.tsx
@@ -3,22 +3,19 @@ import style from "./codeComponent.module.css";
 import useButtonsStore from "@/stores/buttonsStore";
 
 interface content {
-  btnId: number;
   typeCode: string;
 }
 
-const CodeComponent: React.FC<content> = ({ btnId, typeCode }) => {
-  const buttons = useButtonsStore((state) => state.buttons);
-
-  const button = buttons.filter((btn) => btn.id === btnId);
+const CodeComponent: React.FC<content> = ({ typeCode }) => {
+  const button = useButtonsStore((state) => state.button);
 
   const buttonCode = (typeCode: string) => {
     if (typeCode === "html") {
-      return button[0].htmlCode;
+      return button?.htmlCode || "";
     } else if (typeCode === "css") {
-      return button[0].cssCode;
+      return button?.cssCode || "";
     } else {
-      return button[0].tailwindCode;
+      return button?.tailwindCode || "";
     }
   };
 

--- a/src/components/codeView/codeView.tsx
+++ b/src/components/codeView/codeView.tsx
@@ -5,11 +5,7 @@ import { RiTailwindCssFill } from "react-icons/ri";
 import CodeComponent from "../codeComponent/codeComponent";
 import { useState } from "react";
 
-interface content {
-  btnId: number;
-}
-
-const CodeView: React.FC<content> = ({ btnId }) => {
+const CodeView = () => {
   const [html, setHtml] = useState(true);
   const [css, setCss] = useState(window.innerWidth > 640 ? true : false);
   const [tailwind, setTailwind] = useState(false);
@@ -93,9 +89,9 @@ const CodeView: React.FC<content> = ({ btnId }) => {
         </li>
       </ul>
       <div className="w-full h-[70%] 4xl:h-[80%] 5xl:h-[90%] flex justify-center items-center gap-8">
-        {html && <CodeComponent btnId={btnId} typeCode="html" />}
-        {css && <CodeComponent btnId={btnId} typeCode="css" />}
-        {tailwind && <CodeComponent btnId={btnId} typeCode="tailwind" />}
+        {html && <CodeComponent typeCode="html" />}
+        {css && <CodeComponent typeCode="css" />}
+        {tailwind && <CodeComponent typeCode="tailwind" />}
       </div>
     </div>
   );

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ButtonView from "../buttonView/buttonView";
 import CodeView from "../codeView/codeView";
 import useModalStore from "@/stores/modalStore";
+import useButtonsStore from "@/stores/buttonsStore";
 
 const Modal = () => {
   const [darkMode, setDarkMode] = useState(true);
@@ -13,6 +14,19 @@ const Modal = () => {
   const setModal = useModalStore((state) => state.setModal);
   const btnId = useModalStore((state) => state.btnId);
   const active = useModalStore((state) => state.active);
+
+  const button = useButtonsStore((state) => state.button);
+  const getButtonById = useButtonsStore((state) => state.getButtonById);
+
+  useEffect(() => {
+    const fetchData = () => {
+      if (btnId) {
+        getButtonById(btnId.toString());
+      }
+    };
+
+    fetchData();
+  }, [btnId]);
 
   return (
     <>
@@ -68,13 +82,9 @@ const Modal = () => {
               } `}
             >
               {viewActive == "button" ? (
-                <ButtonView
-                  idBtn={btnId || 1}
-                  darkMode={darkMode}
-                  setDarkMode={setDarkMode}
-                />
+                <ButtonView darkMode={darkMode} setDarkMode={setDarkMode} />
               ) : (
-                <CodeView btnId={btnId || 1} />
+                <CodeView />
               )}
             </div>
           </div>

--- a/src/stores/buttonsStore.ts
+++ b/src/stores/buttonsStore.ts
@@ -51,11 +51,11 @@ const getButtons = async (
 
 const getButtonById = async (id: string) => {
   try {
-    let url = `${API_URL}buttons?id=${id}`;
+    let url = `${API_URL}buttons/${id}`;
 
     const response = await axios.get(url);
 
-    return response.data[0];
+    return response.data;
   } catch (error) {
     console.error("Error al obtener el botón:", error);
     throw error;


### PR DESCRIPTION
Antes no me di cuenta y pasaba el id en el header, ahora se pasa como param y asi ya no depende de todos los filtros que se aplican en buttons. Por lo que si vos tenes filtros aplicados, y despues buscas un boton que no este en el rango en el que se aplico el filtro, ahora si lo podes buscar.