### PR TITLE
refactor: the options of the language select

### DIFF
--- a/src/components/languageSelect/languageSelect.tsx
+++ b/src/components/languageSelect/languageSelect.tsx
@@ -2,6 +2,19 @@ import React from "react";
 import { IoLanguageSharp } from "react-icons/io5";
 import { TiArrowSortedDown } from "react-icons/ti";
 
+const languageOptions = [
+  {
+    id: 1,
+    value: "es",
+    label: "ES",
+  },
+  {
+    id: 2,
+    value: "en",
+    label: "EN",
+  },
+];
+
 const LanguageSelect = () => {
   return (
     <div className="flex flex-col">
@@ -14,12 +27,13 @@ const LanguageSelect = () => {
           name="language"
           className="appearance-none w-full xsm:px-5 sm:px-6 md:px-8 2xl:px-10 bg-transparent border border-[#C7C7C7] rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[#4a90e2] cursor-pointer"
         >
-          <option value="es" className="bg-[#191919]">
-            ES
-          </option>
-          <option value="en" className="bg-[#191919]">
-            EN
-          </option>
+          {languageOptions.map((lo) => {
+            return (
+              <option value={lo.value} key={lo.id} className="bg-[#191919]">
+                {lo.label}
+              </option>
+            );
+          })}
         </select>
         <TiArrowSortedDown className="absolute top-1.5 right-3 mn:pr-1 pointer-events-none" />
       </div>


### PR DESCRIPTION
Simplemente lo que hace es que en lugar de tener hardcodeado las options, las saca de un array, por ahora solo habran dos idiomas, pero si en un futuro habran mas, podre simplemente agregar el idioma al array y ya.