### PR TITLE
fix: error in the store if button not found

### DIFF
--- a/src/stores/buttonsStore.ts
+++ b/src/stores/buttonsStore.ts
@@ -80,6 +80,7 @@ const useButtonsStore = create<State>((set) => ({
       set({ button: button });
     } catch (error) {
       console.error("Error en la store:", error);
+      set({button: null})
     }
   },
   getRandomButton: async (id) => {
@@ -88,6 +89,7 @@ const useButtonsStore = create<State>((set) => ({
       set({ randomButton: button });
     } catch (error) {
       console.error("Error en la store:", error);
+      set({randomButton: null})
     }
   },
 }));


### PR DESCRIPTION
Cuando no se encontraba un botón por id o random, aun asi en la store quedaba guardado el ultimo encontrado, por ejemplo. Si vos buscas 760 y aun un boton con id 76 te lo va a poner, y ese 760 queda como error y nada mas, pero te muestra el 76.